### PR TITLE
Aggiornato Dockerfile e aggiunto .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+npm-debug.log
+.DS_Store
+*.log
+*.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ COPY . .
 EXPOSE 3000
 
 # Define the command to start your Nest.js app
-CMD ["npm", "run", "migrate", "&&", "npm", "run", "start"]
+CMD ["npm", "run", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,19 +7,17 @@ WORKDIR /usr/src/app
 # Copy package.json and package-lock.json (if available)
 COPY package*.json ./
 
-# Install Nest.js dependencies
-RUN npm install
+# Install Nest.js dependencies excluding devDependencies
+RUN npm install --only=production
+
+# Install additional dependencies for Nest.js (swagger, drizzle-orm, pg)
+RUN npm install @nestjs/swagger swagger-ui-express drizzle-orm pg
 
 # Copy all the local files to the container
 COPY . .
-
-RUN npm install --save @nestjs/swagger swagger-ui-express
-RUN npm install drizzle-orm pg
 
 # Expose the port your app runs on (ensure it matches the port in your Nest.js app)
 EXPOSE 3000
 
 # Define the command to start your Nest.js app
-
-CMD ["npm", "run", "migrate"]
-CMD ["npm", "run", "start"]
+CMD ["npm", "run", "migrate", "&&", "npm", "run", "start"]

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,8 +11,18 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { SwaggerModule, DocumentBuilder, SwaggerDocumentOptions } from '@nestjs/swagger';
+import { exec } from 'child_process';
 
 async function bootstrap() {
+	exec('npm run migrate', (err, stdout, stderr) => {
+		if (err) {
+			console.log(err);
+			return;
+		}
+		console.log(stdout);
+		console.log(stderr);
+	});
+
 	const app = await NestFactory.create(AppModule);
 	const config = new DocumentBuilder()
 		.setTitle('Easy Meal')


### PR DESCRIPTION
# MODIFCHE EFFETTUATE
## Dockerfile
Le dipendenze di produzione vengono installate separatamente dalle dipendenze specifiche di Nest.js. L'istruzione `npm install --only=production` installa solo le dipendenze necessarie per l'esecuzione dell'applicazione, escludendo le dipendenze di sviluppo.

### Perchè? 
Se il file _package.json_ non cambia, la cache del layer con le dipendenze di produzione viene sfruttata pienamente, riducendo i tempi di build quando si modificano solo i file dell'applicazione e non le dipendenze

## .dockerignore 
### Perchè?
Siccome abbiamo già copiato con COPY anche i node_modules evitiamo di copiarla una seconda volta aggiungendo la folder al file _.dockerignore_